### PR TITLE
Feat: Add functionality to save input URL as a query parameter and prefill it on page load

### DIFF
--- a/app/components/UrlInputForm.tsx
+++ b/app/components/UrlInputForm.tsx
@@ -1,0 +1,33 @@
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { Send } from "lucide-react"
+
+export const UrlInputForm = ({
+  url,
+  onChange,
+  onSubmit,
+  isLoading,
+}: {
+  url: string
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onSubmit: (e: React.FormEvent) => void
+  isLoading: boolean
+}) => (
+  <form onSubmit={onSubmit} className="relative mb-12">
+    <Input
+      type="text"
+      value={url}
+      onChange={onChange}
+      placeholder="Enter your URL here..."
+      className="w-full h-14 pl-4 pr-12 bg-white dark:bg-gray-900/50 border-gray-200 dark:border-gray-800 rounded-xl text-gray-900 dark:text-white placeholder:text-gray-500 focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-600 transition-all"
+      required
+    />
+    <Button
+      type="submit"
+      disabled={isLoading}
+      className="absolute right-2 top-2 h-10 px-4 bg-blue-600 hover:bg-blue-700 dark:bg-blue-600 dark:hover:bg-blue-700 text-white rounded-lg transition-all"
+    >
+      {isLoading ? "Loading..." : <><Send className="w-4 h-4 mr-2" />Preview</>}
+    </Button>
+  </form>
+)


### PR DESCRIPTION
Hi!

Thanks so much for creating MetaCheck — it's a really helpful tool for previewing how links appear on different platforms. I love it and wish the project continued success!

This PR adds a small improvement to make it easier to share results with others:

**What’s new:**
- When you enter a URL and submit, it’s saved in the query string as `?url=…`
- If someone opens a link with that query parameter, the input is prefilled and the results are shown right away

**Why it matters:**
- This makes it easy to share previews — just send someone a link like
`https://metacheck.appstate.co/?url=example.com`, and they’ll see exactly what you saw.

Hope this is helpful! Happy to tweak anything based on feedback — and thanks again for building such a great tool.

Best,
Alena